### PR TITLE
catch TypeError in BaseGeometry.empty

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -225,7 +225,7 @@ class BaseGeometry(object):
         if not self._is_empty and not self._other_owned and self.__geom__:
             try:
                 self._lgeos.GEOSGeom_destroy(self.__geom__)
-            except AttributeError:
+            except (AttributeError, TypeError):
                 pass  # _lgeos might be empty on shutdown
         self._is_empty = True
         self.__geom__ = val


### PR DESCRIPTION
Fixes "`Exception TypeError: TypeError("'NoneType' object is not callable",) in <bound method MultiPolygon.__del__ of <shapely.geometry.multipolygon.MultiPolygon object at 0x2b074e819590>>'"

Likely also related to https://github.com/Toblerity/Shapely/issues/473